### PR TITLE
MacOS X build fixes

### DIFF
--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -10,11 +10,19 @@ else
     linux_possible=false
 fi
 
-if [[ $(getconf _POSIX_TIMERS) -ge 200112 ]]; then
+ptimer=$(getconf _POSIX_TIMERS)
+case $ptimer in
+undefined)
+  posix_timers_possible=false
+  ;;
+*)
+  if [[ $timer -ge 200111 ]]; then
     posix_timers_possible=true
-else
+  else
     posix_timers_possible=false
-fi
+  fi
+  ;;
+esac
 
 if [[ -e setup.data ]]; then
     sed -i '/^\(linux\|posix_timers\)_possible=/d' setup.data


### PR DESCRIPTION
With this change, there are still quite a few bits of breakage:

```

sed '/^#/D' setup.ml > setup_dev.ml
ocamlfind ocamlopt -o setup-dev.exe -linkpkg -package ocamlbuild,oasis.dynrun setup_dev.ml ||     ocamlfind ocamlc -o setup-dev.exe -linkpkg -package ocamlbuild,oasis.dynrun setup_dev.ml || true
rm -f setup_dev.*
./setup-dev.exe -configure 
W: No replace section found in file Makefile
discover.sh:46:4: warning: #warning "cpp test --defined(LINUX_EXT)-- was false"
discover.sh:47:4: warning: #warning "Feature LINUX_EXT will not be availlable"
discover.sh:52:4: warning: #warning "cpp test --defined(POSIX_TIMERS)-- was false"
discover.sh:53:4: warning: #warning "Feature POSIX_TIMERS will not be availlable"
discover.sh:58:4: warning: #warning "cpp test --defined(RLIMIT_NICE)-- was false"
discover.sh:59:4: warning: #warning "Feature RLIMIT_NICE will not be availlable"
discover.sh:67:4: warning: #warning "cpp test --defined MSG_NOSIGNAL-- was false"
discover.sh:68:4: warning: #warning "Bigstring.(unsafe_|really_)?send(to)?(_noblocking)?_no_sigpipe will not be availlable"
discover.sh:73:4: warning: #warning "cpp test --defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS > 0)-- was false"
discover.sh:74:4: warning: #warning "Feature MUTEX_TIMED_LOCK will not be availlable"
discover.sh:80:4: warning: #warning "cpp test --defined(_POSIX_SYNCHRONIZED_IO) && _POSIX_SYNCHRONIZED_IO > 0-- was false"
discover.sh:81:4: warning: #warning "Feature FDATASYNC will not be availlable"

Configuration: 
ocamlfind: ........................................... /Users/avsm/.opam/system/bin/ocamlfind
ocamlc: .............................................. /usr/local/bin/ocamlc.opt
ocamlopt: ............................................ /usr/local/bin/ocamlopt.opt
ocamlbuild: .......................................... /usr/local/bin/ocamlbuild
Package name: ........................................ core
Package version: ..................................... 109.07.00
os_type: ............................................. Unix
system: .............................................. macosx
architecture: ........................................ amd64
ccomp_type: .......................................... cc
ocaml_version: ....................................... 4.00.1
standard_library_default: ............................ /usr/local/lib/ocaml
standard_library: .................................... /usr/local/lib/ocaml
standard_runtime: .................................... /usr/local/bin/ocamlrun
bytecomp_c_compiler: ................................. cc -fno-defer-pop -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT 
native_c_compiler: ................................... cc -D_FILE_OFFSET_BITS=64 -D_REENTRANT
model: ............................................... default
ext_obj: ............................................. .o
ext_asm: ............................................. .s
ext_lib: ............................................. .a
ext_dll: ............................................. .so
default_executable_name: ............................. a.out
systhread_supported: ................................. true
Install architecture-independent files dir: .......... /usr/local
Install architecture-dependent files in dir: ......... $prefix
User executables: .................................... $exec_prefix/bin
System admin executables: ............................ $exec_prefix/sbin
Program executables: ................................. $exec_prefix/libexec
Read-only single-machine data: ....................... $prefix/etc
Modifiable architecture-independent data: ............ $prefix/com
Modifiable single-machine data: ...................... $prefix/var
Object code libraries: ............................... $exec_prefix/lib
Read-only arch-independent data root: ................ $prefix/share
Read-only architecture-independent data: ............. $datarootdir
Info documentation: .................................. $datarootdir/info
Locale-dependent data: ............................... $datarootdir/locale
Man documentation: ................................... $datarootdir/man
Documentation root: .................................. $datarootdir/doc/$pkg_name
HTML documentation: .................................. $docdir
DVI documentation: ................................... $docdir
PDF documentation: ................................... $docdir
PS documentation: .................................... $docdir
findlib_version: ..................................... 1.3.3
is_native: ........................................... true
suffix_program: ...................................... 
Remove a file.: ...................................... rm -f
Remove a directory.: ................................. rm -rf
Turn ocaml debug flag on: ............................ true
Turn ocaml profile flag on: .......................... false
Compiler support generation of .cmxs.: ............... true
OCamlbuild additional flags: ......................... 
Enable linux specific extensions: .................... false
Enable POSIX timers: ................................. false
Create documentations: ............................... true
Compile tests executable and library and run them: ... false
pkg_variantslib: ..................................... /Users/avsm/.opam/system/lib/variantslib
pkg_variantslib_syntax: .............................. /Users/avsm/.opam/system/lib/variantslib
pkg_sexplib_syntax: .................................. /Users/avsm/.opam/system/lib/sexplib
pkg_sexplib: ......................................... /Users/avsm/.opam/system/lib/sexplib
pkg_fieldslib_syntax: ................................ /Users/avsm/.opam/system/lib/fieldslib
pkg_fieldslib: ....................................... /Users/avsm/.opam/system/lib/fieldslib
pkg_bin_prot: ........................................ /Users/avsm/.opam/system/lib/bin_prot
pkg_bin_prot_syntax: ................................. /Users/avsm/.opam/system/lib/bin_prot
pkg_bigarray: ........................................ /usr/local/lib/ocaml
pkg_comparelib_syntax: ............................... /Users/avsm/.opam/system/lib/comparelib
pkg_pa_ounit: ........................................ /Users/avsm/.opam/system/lib/pa_ounit
pkg_pa_pipebang: ..................................... /Users/avsm/.opam/system/lib/pa_pipebang
pkg_res: ............................................. /Users/avsm/.opam/system/lib/res
pkg_unix: ............................................ /usr/local/lib/ocaml
pkg_threads: ......................................... /usr/local/lib/ocaml
ocamldoc: ............................................ /usr/local/bin/ocamldoc

./setup-dev.exe -build 
W: No replace section found in file Makefile
Finished, 1 target (0 cached) in 00:00:00.
getconf: no such configuration parameter `LFS64_CFLAGS'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/backtrace_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/bigstring_marshal_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/bigstring_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
lib/bigstring_stubs.c:684:2: warning: #warning is a language extension [-pedantic]
#warning "MSG_NOSIGNAL not defined; bigstring_send{,msg}_noblocking_no_sigpipe not implemented"
 ^
lib/bigstring_stubs.c:684:2: warning: "MSG_NOSIGNAL not defined; bigstring_send{,msg}_noblocking_no_sigpipe not implemented" [-W#warnings]
lib/bigstring_stubs.c:685:2: warning: #warning is a language extension [-pedantic]
#warning "Try compiling on Linux?"
 ^
lib/bigstring_stubs.c:685:2: warning: "Try compiling on Linux?" [-W#warnings]
4 warnings generated.
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/crc_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/heap_block_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/linux_ext_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/misc.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/ocaml_utils_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/open_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/signal_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
+ ocamlfind ocamlc -ccopt -pipe -ccopt -g -ccopt -fPIC -ccopt -O2 -ccopt -fomit-frame-pointer -ccopt -fsigned-char -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/unix_stubs.c
clang: warning: argument unused during compilation: '-fno-defer-pop'
lib/unix_stubs.c:362:61: error: no member named 'st_atimensec' in 'struct stat64'; did you mean 'st_atimespec'?
    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimensec / 1000000000.0f));
                                                            ^~~~~~~~~~~~
                                                            st_atimespec
/usr/include/sys/stat.h:264:15: note: 'st_atimespec' declared here
struct stat64 __DARWIN_STRUCT_STAT64;
              ^
/usr/include/sys/stat.h:209:2: note: expanded from macro '__DARWIN_STRUCT_STAT64'
        __DARWIN_STRUCT_STAT64_TIMES \
        ^
/usr/include/sys/stat.h:172:18: note: expanded from macro '__DARWIN_STRUCT_STAT64_TIMES'
        struct timespec st_atimespec;           /* time of last access */ \
                        ^
lib/unix_stubs.c:362:74: error: invalid operands to binary expression ('struct timespec' and 'float')
    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimensec / 1000000000.0f));
                                                       ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
lib/unix_stubs.c:363:61: error: no member named 'st_mtimensec' in 'struct stat64'; did you mean 'st_mtimespec'?
    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimensec / 1000000000.0f));
                                                            ^~~~~~~~~~~~
                                                            st_mtimespec
/usr/include/sys/stat.h:264:15: note: 'st_mtimespec' declared here
struct stat64 __DARWIN_STRUCT_STAT64;
              ^
/usr/include/sys/stat.h:209:2: note: expanded from macro '__DARWIN_STRUCT_STAT64'
        __DARWIN_STRUCT_STAT64_TIMES \
        ^
/usr/include/sys/stat.h:173:18: note: expanded from macro '__DARWIN_STRUCT_STAT64_TIMES'
        struct timespec st_mtimespec;           /* time of last data modification */ \
                        ^
lib/unix_stubs.c:363:74: error: invalid operands to binary expression ('struct timespec' and 'float')
    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimensec / 1000000000.0f));
                                                       ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
lib/unix_stubs.c:364:61: error: no member named 'st_ctimensec' in 'struct stat64'; did you mean 'st_ctimespec'?
    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimensec / 1000000000.0f));
                                                            ^~~~~~~~~~~~
                                                            st_ctimespec
/usr/include/sys/stat.h:264:15: note: 'st_ctimespec' declared here
struct stat64 __DARWIN_STRUCT_STAT64;
              ^
/usr/include/sys/stat.h:209:2: note: expanded from macro '__DARWIN_STRUCT_STAT64'
        __DARWIN_STRUCT_STAT64_TIMES \
        ^
/usr/include/sys/stat.h:174:18: note: expanded from macro '__DARWIN_STRUCT_STAT64_TIMES'
        struct timespec st_ctimespec;           /* time of last status change */ \
                        ^
lib/unix_stubs.c:364:74: error: invalid operands to binary expression ('struct timespec' and 'float')
    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimensec / 1000000000.0f));
                                                       ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
lib/unix_stubs.c:400:9: warning: 'stat64' is deprecated: first deprecated in Mac OS X 10.6 [-Wdeprecated-declarations]
  ret = stat64(p, &buf);
        ^
/usr/include/sys/stat.h:466:5: note: 'stat64' declared here
int     stat64(const char *, struct stat64 *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5,__MAC_10_6,__IPHONE_NA,__IPHONE_NA);
        ^
lib/unix_stubs.c:414:9: warning: 'lstat64' is deprecated: first deprecated in Mac OS X 10.6 [-Wdeprecated-declarations]
  ret = lstat64(p, &buf);
        ^
/usr/include/sys/stat.h:465:5: note: 'lstat64' declared here
int     lstat64(const char *, struct stat64 *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5,__MAC_10_6,__IPHONE_NA,__IPHONE_NA);
        ^
lib/unix_stubs.c:426:9: warning: 'fstat64' is deprecated: first deprecated in Mac OS X 10.6 [-Wdeprecated-declarations]
  ret = fstat64(Int_val(fd), &buf);
        ^
/usr/include/sys/stat.h:464:5: note: 'fstat64' declared here
int     fstat64(int, struct stat64 *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5,__MAC_10_6,__IPHONE_NA,__IPHONE_NA);
        ^
lib/unix_stubs.c:602:2: warning: #warning is a language extension [-pedantic]
#warning "_POSIX_SYNCHRONIZED_IO undefined or <= 0; aliasing unix_fdatasync to unix_fsync"
 ^
lib/unix_stubs.c:602:2: warning: "_POSIX_SYNCHRONIZED_IO undefined or <= 0; aliasing unix_fdatasync to unix_fsync" [-W#warnings]
lib/unix_stubs.c:876:2: warning: #warning is a language extension [-pedantic]
#warning "posix timers not present; clock functions undefined"
 ^
lib/unix_stubs.c:876:2: warning: "posix timers not present; clock functions undefined" [-W#warnings]
lib/unix_stubs.c:1079:2: warning: #warning is a language extension [-pedantic]
#warning "POSIX TMO not present; unix_mutex_timedlock undefined"
 ^
lib/unix_stubs.c:1079:2: warning: "POSIX TMO not present; unix_mutex_timedlock undefined" [-W#warnings]
lib/unix_stubs.c:1269:49: warning: passing 'gid_t [16]' to parameter of type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
    n = getgrouplist(c_user, Long_val(v_group), groups, &ngroups);
                                                ^~~~~~
/usr/include/unistd.h:688:43: note: passing argument to parameter here
int      getgrouplist(const char *, int, int *, int *);
                                              ^
lib/unix_stubs.c:1455:2: warning: #warning is a language extension [-pedantic]
#warning "_POSIX_PRIORITY_SCHEDULING not present; sched_setscheduler undefined"
 ^
lib/unix_stubs.c:1455:2: warning: "_POSIX_PRIORITY_SCHEDULING not present; sched_setscheduler undefined" [-W#warnings]
12 warnings and 6 errors generated.
Command exited with code 2.
Compilation unsuccessful after building 21 targets (0 cached) in 00:00:00.
```
