### PR TITLE
Core doesn't build on 32b plateforms.

### DIFF
--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -99,7 +99,7 @@ TEST_MODULE = struct
   TEST_UNIT =
     assert (create ~bit:0 = Int63.of_int 0x1);
     assert (create ~bit:1 = Int63.of_int 0x2);
-    assert (create ~bit:62 = Int63.of_int 0x4000_0000_0000_0000);
+    assert (create ~bit:62 = Int63.of_int64_exn 0x4000_0000_0000_0000L);
   ;;
 
   include Make (struct


### PR DESCRIPTION
Hi,
I tried to update my installation of core (with opam) and it failed to compile because : 

> File "lib/flags.ml", line 102, characters 42-63:
> Integer literal exceeds the range of representable integers of type int
> Preprocessing error on file lib/flags.ml
> Command exited with code 2.

The fix was trivial so... here.
