### PR TITLE
Fix FreeBSD compilation by fixing the cdefs defines.

### DIFF
--- a/lib/bigstring_stubs.c
+++ b/lib/bigstring_stubs.c
@@ -1,9 +1,16 @@
 #define _FILE_OFFSET_BITS 64
 
-#define _GNU_SOURCE             /* recvmmsg */
-
-/* For pread/pwrite */
-#define _XOPEN_SOURCE 500
+#ifdef JSC_RECVMMSG
+ #define _GNU_SOURCE             /* recvmmsg */
+#endif
+ 
+/* Defining _XOPEN_SOURCE on FreeBSD results in some
+   other definitions (MSG_NOSIGNAL) from being hidden. */
+#ifdef __linux__
+/* For pread/pwrite >= 500 */
+/* For ipv6 >= 600         */
+#define _XOPEN_SOURCE 600
+#endif
 
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
_GNU_SOURCE should only be defined when recvmmsg is active.  Might want
to guard this inside a __linux__ ifdef too.

_XOPEN_SOURCE needs to be 600 to expose to the IPv6 functions.
However, it still shouldn't be defined on FreeBSD as it then hides the
__BSD_VISIBLE-guarded MSG_NOSIGNAL.  So bump the version to be accurate,
and then hide it in a __linux__ guard.

Not heavily tested on Linux yet, so please doublecheck. 
Closes #18
