### PR TITLE
BUG: Fix build on OSX: add missing 'close' function to Epoll

### DIFF
--- a/lib/linux_ext.ml
+++ b/lib/linux_ext.ml
@@ -879,6 +879,7 @@ module Epoll = struct
 
   let invariant _               = assert false
 
+  let close _                   = assert false
   let find _ _                  = assert false
   let find_exn _ _              = assert false
   let set _ _ _                 = assert false


### PR DESCRIPTION
The Epoll.close function was recently added to Linux_ext, but it wasn't also
added to the "epoll unimplemented" module, so Core fails to build on OSX. This
adds the close function to the "unimplemented" module.

Signed-off-by: Mike McClurg mike.mcclurg@gmail.com
