### PR TITLE
Solaris 11/OpenIndiana building patch

### DIFF
--- a/lib/bigstring_stubs.c
+++ b/lib/bigstring_stubs.c
@@ -29,6 +29,8 @@
 #elif __GLIBC__
 #include <byteswap.h>
 #include <malloc.h>
+#elif __sun
+#include <sys/types.h>
 #else
 #include <sys/types.h>
 #include <sys/endian.h>

--- a/lib/time_stubs.c
+++ b/lib/time_stubs.c
@@ -54,8 +54,10 @@ CAMLprim value core_timegm (value tm_val) {
   tm.tm_wday = Int_val(Field(tm_val,6));
   tm.tm_yday = Int_val(Field(tm_val,7));
   tm.tm_isdst = 0;  /*  tm_isdst is not used by timegm (which sets it to 0) */
+#ifndef __sun
   tm.tm_gmtoff = 0; /* tm_gmtoff is not used by timegm (which sets it to 0) */
   tm.tm_zone = NULL;
+#endif
 
   res = timegm(&tm);
 


### PR DESCRIPTION
This patch makes core compile on Solaris 11/OpenIndiana, it's not the best way as it detects the platform by using __sun macro definition which is obviously present only on Solaris-based operating systems. However this can further be improved. I hope you'll find it useful and will take steps to implement support for this less popular platform
