### PR TITLE
Allow zoneinfo location to be specified in an env variable

### DIFF
--- a/lib/zone.ml
+++ b/lib/zone.ml
@@ -359,10 +359,14 @@ module Stable = struct
         table        : t String.Table.t
       }
 
+      let zone_from_env_or_default () =
+        Option.value (Sys.getenv "TZDIR") ~default:"/usr/share/zoneinfo/"
+      ;;
+
       let the_one_and_only =
         {
           full    = false;
-          basedir = "/usr/share/zoneinfo/";
+          basedir = zone_from_env_or_default ();
           table   = String.Table.create ();
         }
       ;;


### PR DESCRIPTION
Allow ability to override the location of zoneinfo via the variable CORE_ZONEINFO

I can't get core to compile locally for some reason so I have not compiled and tested this.  Hopefully if the patch is liked someone can put the finishing touches on it if I have made a mistake.
