### PR TITLE
Fixed accessing subsecond timestamp values of struct stat on POSIX.1-2008.09 / X/Open 7 systems

### DIFF
--- a/lib/unix_stubs.c
+++ b/lib/unix_stubs.c
@@ -434,7 +434,10 @@ static value core_stat_aux_64(struct stat64 *buf)
   CAMLparam0();
   CAMLlocal5(atime, mtime, ctime, offset, v);
 
-  #if defined _BSD_SOURCE || defined _SVID_SOURCE
+  #if defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || \
+    defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L || \
+    defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
+
     atime = caml_copy_double((double) buf->st_atime + (buf->st_atim.tv_nsec / 1000000000.0f));
     mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtim.tv_nsec / 1000000000.0f));
     ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctim.tv_nsec / 1000000000.0f));


### PR DESCRIPTION
According to stat (2) manual http://man7.org/linux/man-pages/man2/stat.2.html#NOTES

This is the fix to the problem already encountered on some Arch Linux distribution (https://groups.google.com/forum/#!topic/ocaml-core/5XB2ds7cYzQ) (I also have Arch). It's  based on the stackoverflow question http://stackoverflow.com/questions/19802098/accessing-subsecond-timestamp-values-of-struct-stat-in-a-portable-way.
