### PR TITLE
Fix: inconsistent use of caml_stat_* functions

### DIFF
--- a/src/bigstring_stubs.c
+++ b/src/bigstring_stubs.c
@@ -550,7 +550,7 @@ static inline ssize_t writev_in_blocking_section(
   CAMLparam1(v_iovecs);  /* To protect bigstrings outside of OCaml lock */
   caml_enter_blocking_section();
     ret = writev(Int_val(v_fd), iovecs, count);
-    free(iovecs);
+    caml_stat_free(iovecs);
   caml_leave_blocking_section();
   CAMLreturn(ret);
 }
@@ -587,7 +587,7 @@ CAMLprim value bigstring_writev_assume_fd_is_nonblocking_stub(
     ret = writev_in_blocking_section(v_fd, v_iovecs, iovecs, count);
   else {
     ret = writev(Int_val(v_fd), iovecs, count);
-    free(iovecs);
+    caml_stat_free(iovecs);
   }
   if (ret == -1) uerror("writev_assume_fd_is_nonblocking", Nothing);
   return Val_long(ret);
@@ -711,14 +711,14 @@ CAMLprim value bigstring_sendmsg_nonblocking_no_sigpipe_stub(
       msghdr.msg_iov = iovecs;
       msghdr.msg_iovlen = count;
       ret = sendmsg(Int_val(v_fd), &msghdr, nonblocking_no_sigpipe_flag);
-      free(iovecs);
+      caml_stat_free(iovecs);
     caml_leave_blocking_section();
     End_roots();
   } else {
     msghdr.msg_iov = iovecs;
     msghdr.msg_iovlen = count;
     ret = sendmsg(Int_val(v_fd), &msghdr, nonblocking_no_sigpipe_flag);
-    free(iovecs);
+    caml_stat_free(iovecs);
   }
   if (ret == -1 && errno != EAGAIN && errno != EWOULDBLOCK)
     uerror("sendmsg_nonblocking_no_sigpipe", Nothing);

--- a/src/syslog_stubs.c
+++ b/src/syslog_stubs.c
@@ -70,7 +70,7 @@ CAMLprim value core_syslog_syslog(value v_priority, value v_message) {
   memcpy(message, String_val(v_message), len);
   caml_enter_blocking_section();
   syslog(Int_val(v_priority), "%s", message);
-  free(message);
+  caml_stat_free(message);
   caml_leave_blocking_section();
   return Val_unit;
 }


### PR DESCRIPTION
Hello. I'm doing a large-scale study of C stub sources on OPAM.

Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.

Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.
