### PR TITLE
Fix corebuild after move to ppx_driver

### DIFF
--- a/corebuild
+++ b/corebuild
@@ -2,10 +2,8 @@
 
 ocamlbuild \
     -use-ocamlfind \
-    -syntax camlp4o \
     -pkg core \
-    -pkg sexplib.syntax,comparelib.syntax,fieldslib.syntax,variantslib.syntax \
-    -pkg bin_prot.syntax \
+    -tag "ppx(ppx-jane -as-ppx)" \
     -tag thread \
     -tag debug \
     -tag bin_annot \


### PR DESCRIPTION
`corebuild` was unable to build a program.

```verbatim
$ cat hello_ppx.ml
open Core.Std
let () = printf "hello, ppx!\n"

$ corebuild hello_ppx.native
+ ocamlfind ocamldep -syntax camlp4o -package bin_prot.syntax -package sexplib.syntax,comparelib.syntax,fieldslib.syntax,variantslib.syntax -package core -modules hello_ppx.ml > hello_ppx.ml.depends
ocamlfind: Package `bin_prot.syntax' not found
Command exited with code 2.
Compilation unsuccessful after building 1 target (0 cached) in 00:00:00.
```
