### PR TITLE
build on OS X

### DIFF
--- a/src/discover.sh
+++ b/src/discover.sh
@@ -91,7 +91,7 @@ int main () {
      "defined(_POSIX_SYNCHRONIZED_IO) && _POSIX_SYNCHRONIZED_IO > 0")
 
   $(cpp_test JSC_THREAD_CPUTIME \
-	  "defined(_POSIX_THREAD_CPUTIME)")
+	  "defined(_POSIX_THREAD_CPUTIME) && defined(LINUX_EXT)")
 
   return 0;
 }

--- a/src/jbuild
+++ b/src/jbuild
@@ -3,7 +3,7 @@
 (rule
  ((targets (config.h))
   (deps (discover.sh))
-  (action "./${<} ${OCAML} ${OCAMLC} config.h -DLINUX_EXT -DPOSIX_TIMERS -DWORDEXP")))
+  (action "./${<} ${OCAML} ${OCAMLC} config.h -DPOSIX_TIMERS -DWORDEXP")))
 
 (library
  ((name core)


### PR DESCRIPTION
This attempts to fix a couple of issues found when building on Mac OS X.

* OS X is not linux, unset `LINUX_EXT` - this should probably be detected in `discover.sh` and not hardcoded in the `jbuild`.
* `pthread_getcpuclockid` is unavailable on OS X