### PR TITLE
Fix discover to work on mac os X

### DIFF
--- a/src/discover.sh
+++ b/src/discover.sh
@@ -16,7 +16,7 @@ if getconf GNU_LIBC_VERSION | \
     set -- -DTIMERFD "$@"
 fi
 
-eval $($OCAMLC -config | sed -r 's/: /="/;s/$/"/')
+eval $($OCAMLC -config | sed -e 's/: /="/;s/$/"/')
 if [[ $system == linux ]]; then
     set -- -DLINUX_EXT "$@"
 fi


### PR DESCRIPTION
i'm guessing a typo that GNU sed allows but the stricter BSD sed doesn't like?