### PR TITLE
use quoted args "$@" in corebuild script

### DIFF
--- a/corebuild
+++ b/corebuild
@@ -10,4 +10,4 @@ ocamlbuild \
     -tag short_paths \
     -cflags "-w A-4-33-40-41-42-43-34-44" \
     -cflags -strict-sequence \
-    $@
+    "$@"


### PR DESCRIPTION
Using `$@` will cause arguments containing whitespace to be expanded into distinct words, among other things.