### PR TITLE
Implement support for sending UDP for macOS

### DIFF
--- a/config/test.c
+++ b/config/test.c
@@ -46,10 +46,16 @@
 "OUT:#undef JSC_ARCH_SIXTYFOUR"
 #endif
 
-#if defined MSG_NOSIGNAL
+#if defined(MSG_NOSIGNAL)
 "OUT:#define JSC_MSG_NOSIGNAL"
 #else
 "OUT:#undef JSC_MSG_NOSIGNAL"
+#endif
+
+#if defined(SO_NOSIGPIPE)
+"OUT:#define JSC_SO_NOSIGPIPE"
+#else
+"OUT:#undef JSC_SO_NOSIGPIPE"
 #endif
 
 #if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS > 0)

--- a/src/bigstring.ml
+++ b/src/bigstring.ml
@@ -158,6 +158,15 @@ let pwrite_assume_fd_is_nonblocking fd ~offset ?(pos = 0) ?len bstr =
   unsafe_pwrite_assume_fd_is_nonblocking fd ~offset ~pos ~len bstr
 
 #ifdef JSC_MSG_NOSIGNAL
+#define JSC_NOSIGPIPE
+#endif
+
+#ifdef JSC_SO_NOSIGPIPE
+#define JSC_NOSIGPIPE
+#endif
+
+#ifdef JSC_NOSIGPIPE
+
 external unsafe_really_send_no_sigpipe
   : file_descr -> pos : int -> len : int -> t -> unit
   = "bigstring_really_send_no_sigpipe_stub"

--- a/src/bigstring_stubs.c
+++ b/src/bigstring_stubs.c
@@ -662,11 +662,19 @@ CAMLprim value bigstring_recvmmsg_assume_fd_is_nonblocking_stub(
 
 #endif  /* JSC_RECVMMSG */
 
-#ifdef MSG_NOSIGNAL
+#if defined(JSC_MSG_NOSIGNAL) || defined(JSC_SO_NOSIGPIPE)
+
+#if defined(JSC_MSG_NOSIGNAL)
 MakeReallyOutputFun(send_no_sigpipe,
                     written = send(fd, bstr, len, MSG_NOSIGNAL))
 
 static int nonblocking_no_sigpipe_flag = MSG_DONTWAIT | MSG_NOSIGNAL;
+#elif defined(JSC_SO_NOSIGPIPE)
+MakeReallyOutputFun(send_no_sigpipe,
+                    written = send(fd, bstr, len, SO_NOSIGPIPE))
+
+static int nonblocking_no_sigpipe_flag = MSG_DONTWAIT | SO_NOSIGPIPE;
+#endif
 
 CAMLprim value bigstring_send_nonblocking_no_sigpipe_stub(
   value v_fd, value v_pos, value v_len, value v_bstr)
@@ -724,6 +732,6 @@ CAMLprim value bigstring_sendmsg_nonblocking_no_sigpipe_stub(
   return Val_long(ret);
 }
 #else
-#warning "MSG_NOSIGNAL not defined; bigstring_send{,msg}_noblocking_no_sigpipe not implemented"
-#warning "Try compiling on Linux?"
-#endif
+#warning "Neither MSG_NOSIGNAL nor SO_NOSIGPIPE defined; bigstring_send{,msg}_noblocking_no_sigpipe not implemented"
+#warning "Try compiling on Linux/mac OS?"
+#endif /* JSC_MSG_NOSIGNAL || JSC_SO_NOSIGPIPE */

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -57,6 +57,17 @@ int main()
 }
 |}
 
+let so_nosigpipe_code = {|
+#include <sys/types.h>
+#include <sys/socket.h>
+
+int main()
+{
+   send(0, "", 0, SO_NOSIGPIPE);
+   return 0;
+}
+|}
+
 let mutex_timed_lock_code = {|
 #include <pthread.h>
 #include <time.h>
@@ -136,6 +147,7 @@ let () =
         [ "TIMERFD"          , timerfd_code          , []
         ; "WORDEXP"          , wordexp_code          , []
         ; "MSG_NOSIGNAL"     , msg_nosignal_code     , []
+        ; "SO_NOSIGPIPE"     , so_nosigpipe_code     , []
         ; "FDATASYNC"        , fdatasync_code        , []
         ; "RECVMMSG"         , recvmmsg_code         , []
         ; "MUTEX_TIMED_LOCK" , mutex_timed_lock_code , ["-lpthread"]


### PR DESCRIPTION
The reason it didn't work is because `bigstring` needs a way to send strings in a way where it is not interrupted by `SIGPIPE`. The proper flag to do so in GNU/Linux is `MSG_NOSIGNAL`, but this is not defined on macOS and probably at least some BSDs. This commit adds support for detecting the alternate option, `SO_NOSIGPIPE` and picks that one.

There is another, similar implementation in the `Linux_ext` module, but since it is full of GNU/Linux specific code, it was not touched.

Presumably this also works in FreeBSD (which includes `SO_NOSIGPIPE`) and DragonFlyBSD (which has both MSG_NOSIGNAL and SO_NOSIGPIPE) though I have neither to test.

Talking about testing, here's the sample program which I used to test. Didn't work before, but now with this test it does:

```ocaml
(* corebuild -pkg async sendudp.native *)
open Core
open Async

let buf = "hello world\n"
  |> Iobuf.of_string
  |> Iobuf.read_only

let addr = Unix.Inet_addr.of_string "127.0.0.1"

let socket_addr = Unix.Socket.Address.Inet.create addr ~port:2115

let def =
  let s = Socket.create Socket.Type.udp in
  let open Or_error.Monad_infix in
  let send = Udp.sendto () |> Or_error.ok_exn in
  send (Socket.fd s) buf socket_addr

let () =
  Command.async
    ~summary:"herp"
    Command.Spec.(empty)
    (fun () -> def)
  |> Command.run
```

To get the corresponding UDP server to run, launch `nc -ulk 2115` which should print `hello world`.

I was not sure about touching `config/test.c` because it does not seem to be used anymore, with all feature detection now being done in `src/config/discover.ml` but I wasn't sure so I added it there as well.