### PR TITLE
Env is supposed to be Spawn.Env.t

### DIFF
--- a/src/core_unix.ml
+++ b/src/core_unix.ml
@@ -1582,7 +1582,7 @@ let create_process_internal
           ?cwd:(Option.map working_dir ~f:(fun x -> Spawn.Working_dir.Path x))
           ~prog
           ~argv
-          ~env
+          ~env:(Spawn.Env.of_list env)
           ~stdin:in_read
           ~stdout:out_write
           ~stderr:err_write


### PR DESCRIPTION
This fixes the compilation error:

    Error: This expression has type string list
           but an expression was expected of type Spawn.Env.t

As described in the interface:
<https://github.com/janestreet/spawn/blob/6eb9d696e260ee9143bf23689d12c0ae749af95f/src/spawn.mli#L78>

Thank you.