### PR TITLE
Fix inclusion of makedev in Linux on glibc 2.26

### DIFF
--- a/src/unix_stubs.c
+++ b/src/unix_stubs.c
@@ -41,6 +41,13 @@
 #include <netdb.h>
 #include <ifaddrs.h>
 
+/* makedev */
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+/* The BSDs expose the definition for this macro via <sys/types.h>. */
+#else
+#include <sys/sysmacros.h>
+#endif
+
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define stat64 stat
 #define lstat64 lstat


### PR DESCRIPTION
While using core.v0.11.1 with the 4.06.1 release of ocaml, installed
via opam on a Gentoo Linux install with glibc 2.26, linking of ocaml
binaries fails with:

```
 [...]/.opam/4.06.1/lib/core/libcore_stubs.a(unix_stubs.o): In function `unix_mknod_stub':
 [...]/.opam/4.06.1/build/core.v0.11.1/_build/default/src/unix_stubs.c:281: undefined reference to `makedev'
 collect2: error: ld returned 1 exit status
 File "caml_startup", line 1:
 Error: Error during linking
 Command exited with code 2.
```

Glibc had traditionally supported the BSD way of including makedev via
<sys/types.h>, but 2.25 has deprecated this behavior. The macro is now
imported via <sys/sysmacros.h>.

I have tested compilation of this patch both on Linux and MacOS 10.13,
but on top of the v0.11 branch; master is broken for me due to #110. I
have replaced the libcore_stubs.a in my opam installation with the
fixed one, and the 'undefined reference' error disappeared.

Signed-off-by: Marco Leogrande <dark.knight.ita@gmail.com>