### PR TITLE
Fix build on Fedora 29: include header declaring ENOATTR

### DIFF
--- a/src/linux_ext_stubs.c
+++ b/src/linux_ext_stubs.c
@@ -24,6 +24,7 @@
 #include <sys/epoll.h>
 #include <sys/resource.h>
 #include <attr/xattr.h>
+#include <attr/attributes.h>
 #include <arpa/inet.h>
 #include <assert.h>
 #include <limits.h>


### PR DESCRIPTION
Fixes https://github.com/janestreet/core/issues/122

Looks like `ENOATTR` is declared in `attr/attributes.h`:
```
grep ENOATTR /usr/include -r
/usr/include/attr/attributes.h:#ifndef ENOATTR
/usr/include/attr/attributes.h:# define ENOATTR ENODATA
```
