### PR TITLE
create iobuf_set_bounds_and_buffer_sub alias

### DIFF
--- a/src/iobuf.ml
+++ b/src/iobuf.ml
@@ -192,6 +192,11 @@ let set_bounds_and_buffer_sub ~pos ~len ~src ~dst =
   then dst.buf <- src.buf
 ;;
 
+(* use a unique identifier to refer to set_bounds_and_buffer_sub
+ * so that Expert.set_bounds_and_buffer_sub can refer to it
+ * explicitly. *)
+let iobuf_set_bounds_and_buffer_sub = set_bounds_and_buffer_sub
+
 let set_bounds_and_buffer ~src ~dst =
   dst.lo_min <- src.lo_min;
   dst.lo <- src.lo;
@@ -1076,8 +1081,7 @@ module Expert = struct
     = Fields.Direct.set_all_mutable_fields
 
   let set_bounds_and_buffer ~src ~dst = set_bounds_and_buffer ~src ~dst
-  let set_bounds_and_buffer_sub ~pos ~len ~src ~dst =
-    (set_bounds_and_buffer_sub [@inlined]) ~pos ~len ~src ~dst
+  let set_bounds_and_buffer_sub = iobuf_set_bounds_and_buffer_sub
 end
 
 type ok_or_eof = Ok | Eof [@@deriving compare, sexp_of]


### PR DESCRIPTION
Hi everyone,

I encountered a compilation error when attempting to build master on OS X and fixed it locally in the following way. 

I'm concerned that doing this instead of using an inline wrapper will potentially make stack traces involving this function less informative.

There's also probably a better way to fix this problem by using a different annotation or changing which warnings are fatal.

Compiling core's master branch on OS X using opam's 4.07.0 switch and the
default C compiler produces the following error.

    File "src/iobuf.ml", line 1080, characters 4-62:
    Error (warning 55): Cannot inline: Function information unavailable

This patch changes Expert.set_bounds_and_buffer to be defined as
iobuf_set_bounds_and_buffer_sub, rather than as an eta-expanded but
guaranteed-to-be-inlined wrapper.