### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/src/core_unix.ml
+++ b/src/core_unix.ml
@@ -2547,6 +2547,7 @@ type socket_bool_option = Unix.socket_bool_option =
   | SO_ACCEPTCONN
   | TCP_NODELAY
   | IPV6_ONLY
+  | SO_REUSEPORT [@if ocaml_version >= (4, 12, 0)]
 [@@deriving sexp]
 
 type socket_int_option = Unix.socket_int_option =

--- a/src/core_unix.mli
+++ b/src/core_unix.mli
@@ -1595,6 +1595,7 @@ type socket_bool_option =
   | SO_ACCEPTCONN          (** Report whether socket listening is enabled *)
   | TCP_NODELAY            (** Control the Nagle algorithm for TCP sockets *)
   | IPV6_ONLY              (** Forbid binding an IPv6 socket to an IPv4 address *)
+  | SO_REUSEPORT [@if ocaml_version >= (4, 12, 0)] (** Allow reuse of address and port bindings *)
 [@@deriving sexp]
 
 (** The socket options that can be consulted with {!UnixLabels.getsockopt_int}


### PR DESCRIPTION
`SO_REUSEPORT` was added in https://github.com/ocaml/ocaml/pull/9869