### PR TITLE
Add support for OCaml 5.0

### DIFF
--- a/core/src/core_pervasives.ml
+++ b/core/src/core_pervasives.ml
@@ -18,3 +18,10 @@ external raise : exn -> 'a = "%reraise"
 let __FUNCTION__ = "<__FUNCTION__ not supported before OCaml 4.12>"
 
 [%%endif]
+
+[%%if ocaml_version >= (5, 0, 0)]
+
+external ( & ) : bool -> bool -> bool = "%sequand"
+external ( or ) : bool -> bool -> bool = "%sequor"
+
+[%%endif]

--- a/core/src/ephemeron.ml
+++ b/core/src/ephemeron.ml
@@ -1,29 +1,5 @@
 open! Import
-open Std_internal
+open! Std_internal
 module Ephemeron = Caml.Ephemeron.K1
 
 type ('a, 'b) t = ('a Heap_block.t, 'b Heap_block.t) Ephemeron.t
-
-let create = Ephemeron.create
-
-let set_key t = function
-  | None -> Ephemeron.unset_key t
-  | Some v -> Ephemeron.set_key t v
-;;
-
-let get_key = Ephemeron.get_key
-
-let set_data t = function
-  | None -> Ephemeron.unset_data t
-  | Some v -> Ephemeron.set_data t v
-;;
-
-let get_data = Ephemeron.get_data
-let is_key_some t = Ephemeron.check_key t
-let is_key_none t = not (is_key_some t)
-let is_data_some t = Ephemeron.check_data t
-let is_data_none t = not (is_data_some t)
-
-let sexp_of_t sexp_of_a sexp_of_b t =
-  [%sexp_of: a Heap_block.t option * b Heap_block.t option] (get_key t, get_data t)
-;;

--- a/core/src/ephemeron.mli
+++ b/core/src/ephemeron.mli
@@ -13,14 +13,4 @@
 
 open! Import
 
-type ('a, 'b) t [@@deriving sexp_of]
-
-val create : unit -> _ t
-val set_key : ('a, _) t -> 'a Heap_block.t option -> unit
-val get_key : ('a, _) t -> 'a Heap_block.t option
-val set_data : (_, 'b) t -> 'b Heap_block.t option -> unit
-val get_data : (_, 'b) t -> 'b Heap_block.t option
-val is_key_some : _ t -> bool
-val is_key_none : _ t -> bool
-val is_data_some : _ t -> bool
-val is_data_none : _ t -> bool
+type ('a, 'b) t

--- a/core/src/gc.ml
+++ b/core/src/gc.ml
@@ -340,7 +340,6 @@ external promoted_words : unit -> int = "core_gc_promoted_words" [@@noalloc]
 external minor_collections : unit -> int = "core_gc_minor_collections" [@@noalloc]
 external major_collections : unit -> int = "core_gc_major_collections" [@@noalloc]
 external compactions : unit -> int = "core_gc_compactions" [@@noalloc]
-external top_heap_words : unit -> int = "core_gc_top_heap_words" [@@noalloc]
 external major_plus_minor_words : unit -> int = "core_gc_major_plus_minor_words"
 external allocated_words : unit -> int = "core_gc_allocated_words"
 

--- a/core/src/gc.ml
+++ b/core/src/gc.ml
@@ -114,13 +114,13 @@ module Stable = struct
       [@@@ocaml.warning "-3"]
 
       type t = Caml.Gc.control =
-        { mutable minor_heap_size : int
-        ; mutable major_heap_increment : int
-        ; mutable space_overhead : int
-        ; mutable verbose : int
-        ; mutable max_overhead : int
-        ; mutable stack_limit : int
-        ; mutable allocation_policy : int
+        { minor_heap_size : int
+        ; major_heap_increment : int
+        ; space_overhead : int
+        ; verbose : int
+        ; max_overhead : int
+        ; stack_limit : int
+        ; allocation_policy : int
         ; window_size : int
         ; custom_major_ratio : int
         ; custom_minor_ratio : int
@@ -240,13 +240,13 @@ module Control = struct
     [@@@ocaml.warning "-3"]
 
     type t = Caml.Gc.control =
-      { mutable minor_heap_size : int
-      ; mutable major_heap_increment : int
-      ; mutable space_overhead : int
-      ; mutable verbose : int
-      ; mutable max_overhead : int
-      ; mutable stack_limit : int
-      ; mutable allocation_policy : int
+      { minor_heap_size : int
+      ; major_heap_increment : int
+      ; space_overhead : int
+      ; verbose : int
+      ; max_overhead : int
+      ; stack_limit : int
+      ; allocation_policy : int
       ; window_size : int
       ; custom_major_ratio : int
       ; custom_minor_ratio : int

--- a/core/src/gc.ml
+++ b/core/src/gc.ml
@@ -339,13 +339,10 @@ external major_words : unit -> int = "core_gc_major_words" [@@noalloc]
 external promoted_words : unit -> int = "core_gc_promoted_words" [@@noalloc]
 external minor_collections : unit -> int = "core_gc_minor_collections" [@@noalloc]
 external major_collections : unit -> int = "core_gc_major_collections" [@@noalloc]
-external heap_words : unit -> int = "core_gc_heap_words" [@@noalloc]
-external heap_chunks : unit -> int = "core_gc_heap_chunks" [@@noalloc]
 external compactions : unit -> int = "core_gc_compactions" [@@noalloc]
 external top_heap_words : unit -> int = "core_gc_top_heap_words" [@@noalloc]
 external major_plus_minor_words : unit -> int = "core_gc_major_plus_minor_words"
 external allocated_words : unit -> int = "core_gc_allocated_words"
-external run_memprof_callbacks : unit -> unit = "core_gc_run_memprof_callbacks"
 
 let zero = Sys.opaque_identity (int_of_string "0")
 
@@ -466,11 +463,9 @@ module For_testing = struct
         (* Memprof.stop does not guarantee that all memprof callbacks are run (some may be
            delayed if they happened during C code and there has been no allocation since),
            so we explictly flush them *)
-        run_memprof_callbacks ();
         Caml.Gc.Memprof.stop ();
         x
       | exception e ->
-        run_memprof_callbacks ();
         Caml.Gc.Memprof.stop ();
         raise e
     in

--- a/core/src/gc.mli
+++ b/core/src/gc.mli
@@ -268,7 +268,6 @@ external promoted_words : unit -> int = "core_gc_promoted_words" [@@noalloc]
 external minor_collections : unit -> int = "core_gc_minor_collections" [@@noalloc]
 external major_collections : unit -> int = "core_gc_major_collections" [@@noalloc]
 external compactions : unit -> int = "core_gc_compactions" [@@noalloc]
-external top_heap_words : unit -> int = "core_gc_top_heap_words" [@@noalloc]
 
 (** This function returns [major_words () + minor_words ()].  It exists purely for speed
     (one call into C rather than two).  Like [major_words] and [minor_words],

--- a/core/src/gc.mli
+++ b/core/src/gc.mli
@@ -124,13 +124,13 @@ type stat = Stat.t
 
 module Control : sig
   type t =
-    { mutable minor_heap_size : int
+    { minor_heap_size : int
     (** The size (in words) of the minor heap.  Changing this parameter will
         trigger a minor collection.
 
         Default: 262144 words / 1MB (32bit) / 2MB (64bit).
     *)
-    ; mutable major_heap_increment : int
+    ; major_heap_increment : int
     (** How much to add to the major heap when increasing it. If this
         number is less than or equal to 1000, it is a percentage of
         the current heap size (i.e. setting it to 100 will double the heap
@@ -139,7 +139,7 @@ module Control : sig
 
         Default: 15%.
     *)
-    ; mutable space_overhead : int
+    ; space_overhead : int
     (** The major GC speed is computed from this parameter.
         This is the memory that will be "wasted" because the GC does not
         immediately collect unreachable blocks.  It is expressed as a
@@ -148,7 +148,7 @@ module Control : sig
         blocks more eagerly) if [space_overhead] is smaller.
 
         Default: 80. *)
-    ; mutable verbose : int
+    ; verbose : int
     (** This value controls the GC messages on standard error output.
         It is a sum of some of the following flags, to print messages
         on the corresponding events:
@@ -164,7 +164,7 @@ module Control : sig
         - [0x200] Computation of compaction triggering condition.
 
         Default: 0. *)
-    ; mutable max_overhead : int
+    ; max_overhead : int
     (** Heap compaction is triggered when the estimated amount
         of "wasted" memory is more than [max_overhead] percent of the
         amount of live data.  If [max_overhead] is set to 0, heap
@@ -173,13 +173,13 @@ module Control : sig
         If [max_overhead >= 1000000], compaction is never triggered.
 
         Default: 500. *)
-    ; mutable stack_limit : int
+    ; stack_limit : int
     (** The maximum size of the stack (in words).  This is only
         relevant to the byte-code runtime, as the native code runtime
         uses the operating system's stack.
 
         Default: 1048576 words / 4MB (32bit) / 8MB (64bit). *)
-    ; mutable allocation_policy : int
+    ; allocation_policy : int
     (** The policy used for allocating in the heap.  Possible
         values are 0 and 1.  0 is the next-fit policy, which is
         quite fast but can result in fragmentation.  1 is the

--- a/core/src/gc.mli
+++ b/core/src/gc.mli
@@ -267,8 +267,6 @@ external major_words : unit -> int = "core_gc_major_words" [@@noalloc]
 external promoted_words : unit -> int = "core_gc_promoted_words" [@@noalloc]
 external minor_collections : unit -> int = "core_gc_minor_collections" [@@noalloc]
 external major_collections : unit -> int = "core_gc_major_collections" [@@noalloc]
-external heap_words : unit -> int = "core_gc_heap_words" [@@noalloc]
-external heap_chunks : unit -> int = "core_gc_heap_chunks" [@@noalloc]
 external compactions : unit -> int = "core_gc_compactions" [@@noalloc]
 external top_heap_words : unit -> int = "core_gc_top_heap_words" [@@noalloc]
 

--- a/core/src/gc_stubs.c
+++ b/core/src/gc_stubs.c
@@ -45,24 +45,9 @@ CAMLprim value core_gc_major_collections(value unit __attribute__((unused)))
   return Val_long(caml_stat_major_collections);
 }
 
-CAMLprim value core_gc_heap_words(value unit __attribute__((unused)))
-{
-  return Val_long(caml_stat_heap_wsz);
-}
-
-CAMLprim value core_gc_heap_chunks(value unit __attribute__((unused)))
-{
-  return Val_long(caml_stat_heap_chunks);
-}
-
 CAMLprim value core_gc_compactions(value unit __attribute__((unused)))
 {
   return Val_long(caml_stat_compactions);
-}
-
-CAMLprim value core_gc_top_heap_words(value unit __attribute__((unused)))
-{
-  return Val_long(caml_stat_top_heap_wsz);
 }
 
 CAMLprim value core_gc_major_plus_minor_words(value unit __attribute__((unused)))

--- a/core/src/gc_stubs.c
+++ b/core/src/gc_stubs.c
@@ -59,10 +59,3 @@ CAMLprim value core_gc_allocated_words(value unit __attribute__((unused)))
 {
   return Val_long(minor_words() + major_words() - promoted_words());
 }
-
-CAMLprim value core_gc_run_memprof_callbacks(value unit __attribute__((unused)))
-{
-  value exn = caml_memprof_handle_postponed_exn();
-  caml_raise_if_exception(exn);
-  return Val_unit;
-}

--- a/core/src/md5_stubs.c
+++ b/core/src/md5_stubs.c
@@ -1,3 +1,4 @@
+#define CAML_INTERNALS
 #include <unistd.h>
 #include <errno.h>
 #include <caml/alloc.h>
@@ -7,7 +8,6 @@
 #include <caml/bigarray.h>
 #include <core_params.h>
 
-#define CAML_INTERNALS
 #if __GNUC__ < 8
 #pragma GCC diagnostic ignored "-pedantic"
 #endif


### PR DESCRIPTION
Successfully used to compile and run both `magic-trace` and `patdiff` on OCaml 5.0