### PR TITLE
Fix reference to core_unix

### DIFF
--- a/core.opam
+++ b/core.opam
@@ -39,6 +39,6 @@ The Core suite of libraries is an industrial strength alternative to
 OCaml's standard library that was developed by Jane Street, the
 largest industrial user of OCaml.
 
-This is the system-independent part of Core. Unix-specific parts were moved to [core-unix].
+This is the system-independent part of Core. Unix-specific parts were moved to [core_unix].
 "
 conflicts: ["base-domains"]


### PR DESCRIPTION
This PR fixes a typo.  Unix-specific parts were moved to `core_unix` rather than `core-unix`.