### PR TITLE
MSVC support

### DIFF
--- a/core/src/bigstring_stubs.c
+++ b/core/src/bigstring_stubs.c
@@ -14,7 +14,9 @@
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -36,7 +38,9 @@
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #else
+#ifndef _MSC_VER
 #include <endian.h>
+#endif
 #endif
 #define __BYTE_ORDER _BYTE_ORDER
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN

--- a/core/src/dune
+++ b/core/src/dune
@@ -1,5 +1,5 @@
 (rule (targets config.h) (deps)
- (action (bash "cp %{lib:jst-config:config.h} .")))
+ (action (bash "cp '%{lib:jst-config:config.h}' .")))
 
 (library (name core) (public_name core) (install_c_headers time_ns_stubs)
  (libraries base base_bigstring base_for_tests base_quickcheck bin_prot

--- a/core/src/gc_stubs.c
+++ b/core/src/gc_stubs.c
@@ -4,6 +4,15 @@
 #include <caml/memory.h>
 #include <caml/memprof.h>
 
+#if defined(_MSC_VER) && _MSC_VER >= 1500
+# define __unused(x) __pragma( warning (push) ) \
+    __pragma( warning (disable:4189 ) ) \
+    x \
+    __pragma( warning (pop))
+#else
+# define __unused(x) x __attribute__((unused))
+#endif
+
 static intnat minor_words(void) {
   return (intnat)(caml_stat_minor_words +
                   (double)(caml_young_end - caml_young_ptr));
@@ -13,7 +22,7 @@ static intnat promoted_words(void) {
   return ((intnat)caml_stat_promoted_words);
 }
 
-CAMLprim value core_gc_minor_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_minor_words(__unused(value unit)) {
   return Val_long(minor_words());
 }
 
@@ -21,49 +30,47 @@ static intnat major_words(void) {
   return (intnat)(caml_stat_major_words + (double)caml_allocated_words);
 }
 
-CAMLprim value core_gc_major_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_major_words(__unused(value unit)) {
   return Val_long(major_words());
 }
 
-CAMLprim value core_gc_promoted_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_promoted_words(__unused(value unit)) {
   return Val_long(promoted_words());
 }
 
-CAMLprim value core_gc_minor_collections(value unit __attribute__((unused))) {
+CAMLprim value core_gc_minor_collections(__unused(value unit)) {
   return Val_long(caml_stat_minor_collections);
 }
 
-CAMLprim value core_gc_major_collections(value unit __attribute__((unused))) {
+CAMLprim value core_gc_major_collections(__unused(value unit)) {
   return Val_long(caml_stat_major_collections);
 }
 
-CAMLprim value core_gc_heap_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_heap_words(__unused(value unit)) {
   return Val_long(caml_stat_heap_wsz);
 }
 
-CAMLprim value core_gc_heap_chunks(value unit __attribute__((unused))) {
+CAMLprim value core_gc_heap_chunks(__unused(value unit)) {
   return Val_long(caml_stat_heap_chunks);
 }
 
-CAMLprim value core_gc_compactions(value unit __attribute__((unused))) {
+CAMLprim value core_gc_compactions(__unused(value unit)) {
   return Val_long(caml_stat_compactions);
 }
 
-CAMLprim value core_gc_top_heap_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_top_heap_words(__unused(value unit)) {
   return Val_long(caml_stat_top_heap_wsz);
 }
 
-CAMLprim value core_gc_major_plus_minor_words(value unit
-                                              __attribute__((unused))) {
+CAMLprim value core_gc_major_plus_minor_words(__unused(value unit)) {
   return Val_long(minor_words() + major_words());
 }
 
-CAMLprim value core_gc_allocated_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_allocated_words(__unused(value unit)) {
   return Val_long(minor_words() + major_words() - promoted_words());
 }
 
-CAMLprim value core_gc_run_memprof_callbacks(value unit
-                                             __attribute__((unused))) {
+CAMLprim value core_gc_run_memprof_callbacks(__unused(value unit)) {
   value exn = caml_memprof_handle_postponed_exn();
   caml_raise_if_exception(exn);
   return Val_unit;

--- a/core/src/md5_stubs.c
+++ b/core/src/md5_stubs.c
@@ -4,12 +4,16 @@
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include <core_params.h>
+#ifndef _MSC_VER
 #include <errno.h>
+#endif
 #include <unistd.h>
 
 #define CAML_INTERNALS
 #if __GNUC__ < 8
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-pedantic"
+#endif
 #endif
 #include <caml/md5.h>
 #include <caml/sys.h>


### PR DESCRIPTION
### Problem 1

On Windows paths have backslashes:

```
#=== ERROR while compiling core.v0.15.1 =======================================#
# context     2.2.0~alpha0~20221228 | win32/x86_64 | conf-withdkml.2 ocaml-system.4.14.0 | https://opam.ocaml.org#e0171a79
# path        Z:\source\di-ocaml\_opam\.opam-switch\build\core.v0.15.1
# command     C:\Users\beckf\AppData\Local\Programs\DISKUV~1\bin\WITH-D~1.EXE dune build -p core -j 11
# exit-code   1
# env-file    C:\Users\beckf\AppData\Local\opam\log\core-10444-b4cc2f.env
# output-file C:\Users\beckf\AppData\Local\opam\log\core-10444-b4cc2f.out
### output ###
# File "core/src/dune", line 1, characters 0-83:
# 1 | (rule (targets config.h) (deps)
# 2 |  (action (bash "cp %{lib:jst-config:config.h} .")))
# (cd _build/default/core/src && C:\Users\beckf\AppData\Local\Programs\DISKUV~1\tools\MSYS2\usr\bin\bash.exe -e -u -o pipefail -c "cp Z:\source\di-ocaml\_opam\lib\jst-config\config.h .")
# cp: cannot stat 'Z:sourcedi-ocaml_opamlibjst-configconfig.h': No such file or directory
```

Without the single quotes the `cp` will fail for backslashes and spaces (the latter can happen on macOS as well).

PS. Why invoke `bash "cp ..."` at all, instead of just using Dune's `copy` action?

### Problem 2

`unistd.h` is not in the Windows SDK but is rarely needed. Ditto for `endian.h`

### Problem 3

MSVC does not support the GNU `__attribute__((unused))` extension.


Signed-off-by: Jonah Beckford <71855677+jonahbeckford@users.noreply.github.com>