### PR TITLE
OCaml 5.1 support: gc_stubs fix

### DIFF
--- a/core/src/gc_stubs.c
+++ b/core/src/gc_stubs.c
@@ -31,7 +31,11 @@ CAMLprim value core_gc_promoted_words(value unit __attribute__((unused))) {
 }
 
 CAMLprim value core_gc_minor_collections(value unit __attribute__((unused))) {
+#if OCAML_VERSION < 50100
   return Val_long(caml_stat_minor_collections);
+#else
+  return Val_long(atomic_load(&caml_minor_collections_count));
+#endif
 }
 
 CAMLprim value core_gc_major_collections(value unit __attribute__((unused))) {


### PR DESCRIPTION
In OCaml 5.1.0, the number of minor collections is an atomic global state variable (because domains need to synchronize on this count) (see https://github.com/ocaml/ocaml/pull/11750).

This PR updates the `gc_stubs.c` code in order to load this new variable.

This seems to be the only issue stopping `core` to  work on OCaml 5.1.0 .