### PR TITLE
Get core working with MSVC

### DIFF
--- a/core/src/bigstring_stubs.c
+++ b/core/src/bigstring_stubs.c
@@ -14,7 +14,9 @@
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -36,7 +38,9 @@
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #else
+#ifndef _MSC_VER
 #include <endian.h>
+#endif
 #endif
 #define __BYTE_ORDER _BYTE_ORDER
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN

--- a/core/src/dune
+++ b/core/src/dune
@@ -1,5 +1,5 @@
 (rule (targets config.h) (deps)
- (action (bash "cp %{lib:jst-config:config.h} .")))
+ (action (copy %{lib:jst-config:config.h} config.h)))
 
 (library (name core) (public_name core) (install_c_headers time_ns_stubs)
  (libraries base base_bigstring base_for_tests base_quickcheck bin_prot

--- a/core/src/gc_stubs.c
+++ b/core/src/gc_stubs.c
@@ -5,16 +5,25 @@
 #include <caml/memprof.h>
 #include <caml/version.h>
 
+#if defined(_MSC_VER) && _MSC_VER >= 1500
+# define __unused(x) __pragma( warning (push) ) \
+    __pragma( warning (disable:4189 ) ) \
+    x \
+    __pragma( warning (pop))
+#else
+# define __unused(x) x __attribute__((unused))
+#endif
+
 static intnat minor_words(void) {
-  return (intnat)(caml_stat_minor_words +
-                  (double)(caml_young_end - caml_young_ptr));
+  return (intnat) (caml_stat_minor_words +
+            (double) (caml_young_end - caml_young_ptr));
 }
 
 static intnat promoted_words(void) {
   return ((intnat)caml_stat_promoted_words);
 }
 
-CAMLprim value core_gc_minor_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_minor_words(__unused(value unit)) {
   return Val_long(minor_words());
 }
 
@@ -22,15 +31,15 @@ static intnat major_words(void) {
   return (intnat)(caml_stat_major_words + (double)caml_allocated_words);
 }
 
-CAMLprim value core_gc_major_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_major_words(__unused(value unit)) {
   return Val_long(major_words());
 }
 
-CAMLprim value core_gc_promoted_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_promoted_words(__unused(value unit)) {
   return Val_long(promoted_words());
 }
 
-CAMLprim value core_gc_minor_collections(value unit __attribute__((unused))) {
+CAMLprim value core_gc_minor_collections(__unused(value unit)) {
 #if OCAML_VERSION < 50100
   return Val_long(caml_stat_minor_collections);
 #else
@@ -38,25 +47,23 @@ CAMLprim value core_gc_minor_collections(value unit __attribute__((unused))) {
 #endif
 }
 
-CAMLprim value core_gc_major_collections(value unit __attribute__((unused))) {
+CAMLprim value core_gc_major_collections(__unused(value unit)) {
   return Val_long(caml_stat_major_collections);
 }
 
-CAMLprim value core_gc_compactions(value unit __attribute__((unused))) {
+CAMLprim value core_gc_compactions(__unused(value unit)) {
   return Val_long(caml_stat_compactions);
 }
 
-CAMLprim value core_gc_major_plus_minor_words(value unit
-                                              __attribute__((unused))) {
+CAMLprim value core_gc_major_plus_minor_words(__unused(value unit)) {
   return Val_long(minor_words() + major_words());
 }
 
-CAMLprim value core_gc_allocated_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_allocated_words(__unused(value unit)) {
   return Val_long(minor_words() + major_words() - promoted_words());
 }
 
-CAMLprim value core_gc_run_memprof_callbacks(value unit
-                                             __attribute__((unused))) {
+CAMLprim value core_gc_run_memprof_callbacks(__unused(value unit)) {
 // Not implemented on 5.0.0
 #if OCAML_VERSION < 50000
   value res = caml_memprof_handle_postponed_exn();
@@ -68,15 +75,15 @@ CAMLprim value core_gc_run_memprof_callbacks(value unit
 
 #if OCAML_VERSION < 50000
 
-CAMLprim value core_gc_heap_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_heap_words(__unused(value unit)) {
   return Val_long(caml_stat_heap_wsz);
 }
 
-CAMLprim value core_gc_heap_chunks(value unit __attribute__((unused))) {
+CAMLprim value core_gc_heap_chunks(__unused(value unit)) {
   return Val_long(caml_stat_heap_chunks);
 }
 
-CAMLprim value core_gc_top_heap_words(value unit __attribute__((unused))) {
+CAMLprim value core_gc_top_heap_words(__unused(value unit)) {
   return Val_long(caml_stat_top_heap_wsz);
 }
 

--- a/core/src/md5_stubs.c
+++ b/core/src/md5_stubs.c
@@ -6,10 +6,14 @@
 #include <caml/signals.h>
 #include <core_params.h>
 #include <errno.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #if __GNUC__ < 8
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-pedantic"
+#endif
 #endif
 #include <caml/md5.h>
 #include <caml/sys.h>


### PR DESCRIPTION
**oops: I already submitted these changes as part of https://github.com/janestreet/core/pull/161**: When it says "merged after the v0.16 release", does that mean Windows users have to wait approximately 6 months / one year until v0.17 is released?

---

Changes to get `core` working with MSVC:

* MSVC supported unused attribute
* No include of `unistd.h` and `endian.h` for MSVC (`unistd.h` is not needed on MSVC)
* Don't do GCC diagnostic pragmas with MSVC
* Use `(copy)` dune clause to avoid backslashes/spaces on Windows

NOTE: This is a merge to the `v0.16` branch