### PR TITLE
Fix build on MinGW

### DIFF
--- a/core/src/bigstring_stubs.c
+++ b/core/src/bigstring_stubs.c
@@ -38,7 +38,7 @@
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #else
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <endian.h>
 #endif
 #endif


### PR DESCRIPTION
MinGW does not provide endian.h, similar to MSVC. Changing this ifndef from _MSC_VER to _WIN32 to cover both toolchains.

Test Plan:
I compiled the project (at v0.16 tag) with this change and it compiled, but I have not tested further. I have not attempted to compile with MSVC, but I'm quite confident that _WIN32 will be defined.

Fixes https://github.com/janestreet/core/issues/168