### PR TITLE
Add the convenience fun `Time_ns.since`

### DIFF
--- a/core/src/time_ns.ml
+++ b/core/src/time_ns.ml
@@ -22,6 +22,7 @@ let epoch = Span.zero
 let add = Span.( + )
 let sub = Span.( - )
 let diff = Span.( - )
+let since = diff @@ now ()
 let abs_diff t u = Span.abs (diff t u)
 let max = Span.max
 let min = Span.min

--- a/core/src/time_ns_intf.ml
+++ b/core/src/time_ns_intf.ml
@@ -397,6 +397,9 @@ module type Time_ns = sig
   val diff : t -> t -> Span.t
 
   (** overflows silently *)
+  val since : t -> Span.t
+
+  (** overflows silently *)
   val abs_diff : t -> t -> Span.t
 
   val to_span_since_epoch : t -> Span.t


### PR DESCRIPTION
Adds a convenience function to compute the elapsed time. Instead of
```ocaml
Time_ns.(diff (now ()) start)
```
One can do
```ocaml
Time_ns.since start
```