### PR TITLE
Fix predicate typo that disabled five bisimulation operations

### DIFF
--- a/core/test/test_doubly_linked_bisimulation.ml
+++ b/core/test/test_doubly_linked_bisimulation.ml
@@ -612,8 +612,8 @@ let simulate nsteps =
     | Some e -> add_elt e
   in
   let pred = function
-    | Even -> fun n -> n mod 0 = 0
-    | Odd -> fun n -> n mod 0 = 1
+    | Even -> fun n -> n mod 2 = 0
+    | Odd -> fun n -> n mod 2 = 1
   in
   try
     for _ = 1 to nsteps do


### PR DESCRIPTION
`core/test/test_doubly_linked_bisimulation.ml` defines its test predicate as:

```ocaml
let pred = function
  | Even -> fun n -> n mod 0 = 0
  | Odd -> fun n -> n mod 0 = 1
```

`n mod 0` raises `Division_by_zero` for every `n`. It looks like a typo for `n mod 2`.

Five operations take that predicate — `Exists`, `Filter_inplace`, `For_all`, `Find_elt` and `Find`. On a non-empty list both `Doubly_linked` and the `Foil` reference raise, and the simulation loop treats a mutual raise as agreement, so the step is skipped rather than compared. On an empty list the predicate is never reached and they pass trivially. Either way, those five operations have not been testing anything.

### How it was found

While surveying hand-written bisimulation tests in OCaml, as background for [tapecheck](https://github.com/matthiasgoergens/tapecheck), a port of Hypothesis's choice-tape shrinking engine to `base_quickcheck`. The pattern being looked for was tests that silently narrow what they can detect.

Happy to drop this if the predicate was deliberate for some reason I have missed.
